### PR TITLE
Make not found exception message more useful

### DIFF
--- a/Dynamo.Ioc/Index/DirectIndex.cs
+++ b/Dynamo.Ioc/Index/DirectIndex.cs
@@ -57,7 +57,7 @@ namespace Dynamo.Ioc.Index
 			if (type == null)
 				throw new ArgumentNullException("type");
 			if (!_defaultIndex.ContainsKey(type))
-				throw new ArgumentException("type " + type.FullName + " is not in the index");
+				throw new KeyNotFoundException("type " + type.FullName + " is not in the index");
 
 			return _defaultIndex[type];
 		}
@@ -68,7 +68,7 @@ namespace Dynamo.Ioc.Index
 			if (key == null)
 				throw new ArgumentNullException("key");
 			if (!_keyedIndex.ContainsKey(type))
-				throw new ArgumentException("type " + type.FullName + " is not in the index");
+				throw new KeyNotFoundException("type " + type.FullName + " is not in the index");
 
 			return _keyedIndex[type][key];
 		}

--- a/Dynamo.Ioc/Index/DirectIndex.cs
+++ b/Dynamo.Ioc/Index/DirectIndex.cs
@@ -56,6 +56,8 @@ namespace Dynamo.Ioc.Index
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
+			if (!_defaultIndex.ContainsKey(type))
+				throw new ArgumentException("type " + type.FullName + " is not in the index");
 
 			return _defaultIndex[type];
 		}
@@ -65,19 +67,18 @@ namespace Dynamo.Ioc.Index
 				throw new ArgumentNullException("type");
 			if (key == null)
 				throw new ArgumentNullException("key");
+			if (!_keyedIndex.ContainsKey(type))
+				throw new ArgumentException("type " + type.FullName + " is not in the index");
 
 			return _keyedIndex[type][key];
 		}
 		public IRegistration Get<T>()
 		{
-			return _defaultIndex[typeof(T)];
+			return Get(typeof(T));
 		}
 		public IRegistration Get<T>(object key)
 		{
-			if (key == null)
-				throw new ArgumentNullException("key");
-
-			return _keyedIndex[typeof(T)][key];
+			return Get(typeof(T), key);
 		}
 
 		public bool TryGet(Type type, out IRegistration registration)

--- a/Dynamo.Ioc/Index/GroupedIndex.cs
+++ b/Dynamo.Ioc/Index/GroupedIndex.cs
@@ -42,6 +42,8 @@ namespace Dynamo.Ioc.Index
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
+			if (!_index.ContainsKey(type))
+				throw new KeyNotFoundException("type " + type.FullName + " is not in the index");
 
 			return _index[type].Get();
 		}
@@ -49,16 +51,18 @@ namespace Dynamo.Ioc.Index
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
+			if (!_index.ContainsKey(type))
+				throw new KeyNotFoundException("type " + type.FullName + " is not in the index");
 
 			return _index[type].Get(key);
 		}
 		public IRegistration Get<T>()
 		{
-			return _index[typeof(T)].Get();
+			return Get(typeof(T));
 		}
 		public IRegistration Get<T>(object key)
 		{
-			return _index[typeof(T)].Get(key);
+			return Get(typeof(T), key);
 		}
 
 		public bool TryGet(Type type, out IRegistration registration)


### PR DESCRIPTION
Previously if you tried to resolve a type which wasn't in the index, it would simply throw the standard Dictionary message of key not found. I eventually realized that this meant that some type wasn't registered, but I would have to navigate my entire dependency graph by hand trying to figure out what wasn't in the index.

With this change, you can determine what type it cannot find. This is certainly a help in debugging your registration.
